### PR TITLE
Set allowed WebSocket frame size to 100MB

### DIFF
--- a/worker/src/root.js
+++ b/worker/src/root.js
@@ -20,7 +20,7 @@ export default function * main () {
     cache: yield createCache(),
     web3: new Web3(
       new Web3.providers.WebsocketProvider(
-        process.env.ETH_NODE || 'wss://mainnet.infura.io/ws', , {
+        process.env.ETH_NODE || 'wss://mainnet.infura.io/ws', {
         clientConfig: {
           maxReceivedFrameSize: 100000000,
           maxReceivedMessageSize: 100000000,

--- a/worker/src/root.js
+++ b/worker/src/root.js
@@ -18,7 +18,15 @@ export default function * main () {
   const context = {
     db: yield createDb(),
     cache: yield createCache(),
-    web3: new Web3(process.env.ETH_NODE || 'wss://mainnet.infura.io/ws'),
+    web3: new Web3(
+      new Web3.providers.WebsocketProvider(
+        process.env.ETH_NODE || 'wss://mainnet.infura.io/ws', , {
+        clientConfig: {
+          maxReceivedFrameSize: 100000000,
+          maxReceivedMessageSize: 100000000,
+        }
+      })
+    ),
     log: winston.createLogger({
       level: process.env.LOG_LEVEL || 'info',
       transports: [


### PR DESCRIPTION
It seems that some blocks are too big to transfer over WebSocket using Web3.js's default frame size, which leads to "disconnections" (also known as very bad error messages). This is a fix for #1.

Reference: https://github.com/ethereum/web3.js/issues/1217