### PR TITLE
Remove block number from organisations

### DIFF
--- a/worker/src/classifiers/transaction.js
+++ b/worker/src/classifiers/transaction.js
@@ -44,7 +44,6 @@ export default function * () {
     yield put({
       type: 'daolist/dao/DAO_CREATED',
       payload: {
-        block: transaction.blockNumber,
         kit: transaction.to,
         creator: transaction.from,
         transaction: transaction.hash,


### PR DESCRIPTION
There is no reason to keep the block number at which some organisations were created.