### PR TITLE
Remove database indexes from worker source

### DIFF
--- a/worker/src/db.js
+++ b/worker/src/db.js
@@ -16,11 +16,6 @@ export default function createDb () {
   })
 }
 
-export async function createIndexes (db) {
-  await db.createIndex('orgs', 'address', { unique: true })
-  await db.createIndex('apps', 'repository', { unique: true })
-}
-
 export function safeUpsert (collection, filter, update) {
   return collection
     .updateOne(filter, update, { upsert: true })

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -17,9 +17,6 @@ import { root } from './root'
     web3: new Web3(createProvider())
   }
 
-  // Ensure database indexes are present
-  await createIndexes(context.db)
-
   // Run the worker
   try {
     await task({

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -1,6 +1,6 @@
 import { task } from 'cofx'
 import Web3 from 'web3'
-import createDb, { createIndexes } from './db'
+import createDb from './db'
 import createCache from './cache'
 import createLogger from 'pino'
 import createProvider from './provider'


### PR DESCRIPTION
These should be kept in a migration (see #45)