### PR TITLE
Set timeout for IPFS asset fetching

### DIFF
--- a/worker/src/app/version.js
+++ b/worker/src/app/version.js
@@ -15,7 +15,8 @@ export function fetchIpfsAsset (uri, file) {
   }
 
   return got(url.toString(), {
-    json: extension === 'json'
+    json: extension === 'json',
+    timeout: 7500
   }).then(({ body }) => body, () => null)
 }
 


### PR DESCRIPTION
The worker would get stuck on fetching of IPFS assets, so this PR adds a timeout in case the assets don't actually exist anymore.