### PR TITLE
Move filter state out of individual filters to filter container

### DIFF
--- a/website/src/components/Filter/DateRangeFilter.js
+++ b/website/src/components/Filter/DateRangeFilter.js
@@ -1,25 +1,21 @@
-import React, { useState, useEffect } from 'react'
+import React, { useCallback } from 'react'
 import PropTypes from 'prop-types'
 import { _DateRange as DateRange } from '@aragon/ui'
 
 export const FILTER_TYPE_DATE_RANGE = Symbol('FILTER_TYPE_DATE_RANGE')
 export function DateRangeFilter ({
   name,
+  value = {},
   onChange
 }) {
-  const [dateRange, setDateRange] = useState({})
-  useEffect(() => {
-    if (!dateRange.start || !dateRange.end) return
-
-    onChange(name, {
-      between: dateRange
-    })
-  }, [name, dateRange])
+  const setDateRange = useCallback((dateRange) => {
+    onChange(name, dateRange)
+  }, [name])
 
   return <DateRange
     onChange={setDateRange}
-    startDate={dateRange.start}
-    endDate={dateRange.end}
+    startDate={value.start}
+    endDate={value.end}
   />
 }
 

--- a/website/src/components/Filter/DateRangeFilter.js
+++ b/website/src/components/Filter/DateRangeFilter.js
@@ -21,5 +21,9 @@ export function DateRangeFilter ({
 
 DateRangeFilter.propTypes = {
   name: PropTypes.string.isRequired,
+  value: PropTypes.shape({
+    start: PropTypes.string,
+    end: PropTypes.string
+  }),
   onChange: PropTypes.func.isRequired
 }

--- a/website/src/components/Filter/Filter.js
+++ b/website/src/components/Filter/Filter.js
@@ -1,7 +1,7 @@
 import React, { useState, useCallback, useMemo, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import qs from 'qs'
-import { Box, Button, GU } from '@aragon/ui'
+import { Button, GU } from '@aragon/ui'
 import { FILTER_TYPE_DATE_RANGE, DateRangeFilter } from './DateRangeFilter'
 import { FILTER_TYPE_LIST, ListFilter } from './ListFilter'
 import { useLocation } from '../../hooks/router'
@@ -85,34 +85,34 @@ export function Filter ({
       grid-template-rows: auto;
     `}
   `}>
-      {filters.map((filter) => {
-        switch (filter.type) {
-          case FILTER_TYPE_LIST:
-            return <ListFilter
-              name={filter.name}
-              value={filterState[filter.name]}
-              onChange={setFilterValue}
-              items={filter.items}
-              placeholder={filter.placeholder}
-            />
-          case FILTER_TYPE_DATE_RANGE:
-            return <DateRangeFilter
-              name={filter.name}
-              value={filterState[filter.name]}
-              onChange={setFilterValue}
-            />
-          default:
-            throw new Error(`Unknown filter type ${filter.type}`)
-        }
-      })}
-      {isFilterNotEmpty &&
-        <Button
-          css={breakpoint('medium')`grid-column: ${columns};`}
-          onClick={clearFilter}
-        >
-          Clear
-        </Button>
+    {filters.map((filter) => {
+      switch (filter.type) {
+        case FILTER_TYPE_LIST:
+          return <ListFilter
+            name={filter.name}
+            value={filterState[filter.name]}
+            onChange={setFilterValue}
+            items={filter.items}
+            placeholder={filter.placeholder}
+          />
+        case FILTER_TYPE_DATE_RANGE:
+          return <DateRangeFilter
+            name={filter.name}
+            value={filterState[filter.name]}
+            onChange={setFilterValue}
+          />
+        default:
+          throw new Error(`Unknown filter type ${filter.type}`)
       }
+    })}
+    {isFilterNotEmpty &&
+      <Button
+        css={breakpoint('medium')`grid-column: ${columns};`}
+        onClick={clearFilter}
+      >
+        Clear
+      </Button>
+    }
   </div>
 }
 

--- a/website/src/components/Filter/ListFilter.js
+++ b/website/src/components/Filter/ListFilter.js
@@ -1,28 +1,29 @@
-import React, { useState, useEffect } from 'react'
+import React, { useCallback } from 'react'
 import PropTypes from 'prop-types'
 import { DropDown } from '@aragon/ui'
 
 export const FILTER_TYPE_LIST = Symbol('FILTER_TYPE_LIST')
 export function ListFilter ({
   name,
+  value,
   onChange,
   items = [],
   placeholder
 }) {
-  const [selectedItem, setSelectedItem] = useState()
-  useEffect(() => {
-    if (!items[selectedItem]) return
+  const setSelectedItem = useCallback((index) => {
+    if (!items[index]) return
 
-    onChange(name, {
-      eq: items[selectedItem].value
-    })
-  }, [name, items, selectedItem])
+    onChange(name, items[index].value)
+  }, [name, items])
+  const selectedItem = items.findIndex(
+    (item) => item.value === value
+  )
 
   return <DropDown
     placeholder={placeholder}
     items={items.map(({ label }) => label)}
     selected={selectedItem}
-    onChange={(index) => setSelectedItem(index)}
+    onChange={setSelectedItem}
   />
 }
 

--- a/website/src/components/Filter/ListFilter.js
+++ b/website/src/components/Filter/ListFilter.js
@@ -29,6 +29,7 @@ export function ListFilter ({
 
 ListFilter.propTypes = {
   name: PropTypes.string.isRequired,
+  value: PropTypes.string,
   onChange: PropTypes.func.isRequired,
   items: PropTypes.arrayOf(PropTypes.shape({
     label: PropTypes.string.isRequired,


### PR DESCRIPTION
Moves filter state out of the individual filters (`ListFilter`, `DateRangeFilter`) to the filter container (`Filter`). This makes it possible to reflect clearing the filter in the UI.

Also introduces query string parsing and encoding, such that filters are now shareable.

Closes #53 and closes #57.