### PR TITLE
Implement template filter for organisations

### DIFF
--- a/api/src/common/schema.js
+++ b/api/src/common/schema.js
@@ -21,6 +21,7 @@ export default `
   input StringOperators {
     eq: String
     contains: String
+    in: [String]
   }
 
   input BooleanOperators {

--- a/api/src/filter.js
+++ b/api/src/filter.js
@@ -7,6 +7,10 @@ export function transformStringFilter (op) {
     return { $regex: op.contains }
   }
 
+  if (op.in) {
+    return { $in: op.in }
+  }
+
   return {}
 }
 

--- a/api/src/orgs/data.js
+++ b/api/src/orgs/data.js
@@ -18,6 +18,12 @@ export function getOrganisations (
     )
   }
 
+  if (args.filter && args.filter.kit) {
+    filter['kit'] = transformStringFilter(
+      args.filter.kit
+    )
+  }
+
   if (args.filter && args.filter.createdAt) {
     filter['created_at'] = transformDateFilter(
       args.filter.createdAt

--- a/api/src/orgs/schema.js
+++ b/api/src/orgs/schema.js
@@ -6,6 +6,8 @@ export default `
     ens: String
     # The address of the organisation.
     address: String
+    # The kit of the organisation.
+    kit: String
     # The date and time when this organisation was created.
     createdAt: DateTime
   }
@@ -26,6 +28,7 @@ export default `
 
   input OrganisationConnectionFilter {
     app: StringOperators
+    kit: StringOperators
     createdAt: DateOperators
   }
 

--- a/website/src/components/Filter/Filter.js
+++ b/website/src/components/Filter/Filter.js
@@ -17,6 +17,12 @@ function transformFilterValue (
         between: filterValue
       }
     case FILTER_TYPE_LIST:
+      if (filterValue instanceof Array) {
+        return {
+          in: filterValue
+        }
+      }
+
       return {
         eq: filterValue
       }

--- a/website/src/pages/orgs.js
+++ b/website/src/pages/orgs.js
@@ -81,7 +81,7 @@ const KITS = [
   },
   {
     label: 'Company Board',
-    value: '0x4d1A892f42c947fa952b57bc6939b27A96215CfA'
+    value: ['0x4d1A892f42c947fa952b57bc6939b27A96215CfA']
   },
   {
     label: 'Multisig',
@@ -89,11 +89,11 @@ const KITS = [
   },
   {
     label: 'Membership',
-    value: '0x67430642C0c3B5E6538049B9E9eE719f2a4BeE7c'
+    value: ['0x67430642C0c3B5E6538049B9E9eE719f2a4BeE7c']
   },
   {
     label: 'Reputation',
-    value: '0x3a06A6544e48708142508D9042f94DDdA769d04F'
+    value: ['0x3a06A6544e48708142508D9042f94DDdA769d04F']
   }
 ]
 
@@ -155,14 +155,12 @@ export default () => {
                 name: 'app',
                 placeholder: 'Apps',
                 items: APPS
-              },
-              {
+              }, {
                 type: FILTER_TYPE_LIST,
                 name: 'kit',
                 placeholder: 'Templates',
                 items: KITS
-              },
-              {
+              }, {
                 type: FILTER_TYPE_DATE_RANGE,
                 name: 'createdAt'
               }]}

--- a/website/src/pages/orgs.js
+++ b/website/src/pages/orgs.js
@@ -42,6 +42,7 @@ const ORGANISATIONS_QUERY = `
         id
         address
         ens
+        kit
         createdAt
       }
       pageInfo {
@@ -72,6 +73,29 @@ const APPS = [{
   label: 'Voting',
   value: '0x9fa3927f639745e587912d4b0fea7ef9013bf93fb907d29faeab57417ba6e1d4'
 }]
+
+const KITS = [
+  {
+    label: 'Company',
+    value: ['0x705Cd9a00b87Bb019a87beEB9a50334219aC4444', '0x7f3ed10366826a1227025445D4f4e3e14BBfc91d', '0xd737632caC4d039C9B0EEcc94C12267407a271b5']
+  },
+  {
+    label: 'Company Board',
+    value: '0x4d1A892f42c947fa952b57bc6939b27A96215CfA'
+  },
+  {
+    label: 'Multisig',
+    value: ['0x41bbaf498226b68415f1C78ED541c45A18fd7696', '0x87aa2980dde7d2D4e57191f16BB57cF80bf6E5A6']
+  },
+  {
+    label: 'Membership',
+    value: '0x67430642C0c3B5E6538049B9E9eE719f2a4BeE7c'
+  },
+  {
+    label: 'Reputation',
+    value: '0x3a06A6544e48708142508D9042f94DDdA769d04F'
+  }
+]
 
 export default () => {
   const [sort, sortBy] = useSort('createdAt', 'DESC')
@@ -131,7 +155,14 @@ export default () => {
                 name: 'app',
                 placeholder: 'Apps',
                 items: APPS
-              }, {
+              },
+              {
+                type: FILTER_TYPE_LIST,
+                name: 'kit',
+                placeholder: 'Templates',
+                items: KITS
+              },
+              {
                 type: FILTER_TYPE_DATE_RANGE,
                 name: 'createdAt'
               }]}


### PR DESCRIPTION
Adding a template filter next to the current App filter on the organisation page (Fixes #60)

After talking to @onbjerg I decided to split this up in a few commits, so we could easily remove the template filter later on, but keep the `in` filtering in, for other purposes.

The grouping of the templates are provided by @lkngtn 

