### PR TITLE
Put warning about disabled Javascript in noscript tag

### DIFF
--- a/website/src/index.html
+++ b/website/src/index.html
@@ -17,9 +17,9 @@
 	</head>
 
 	<body>
-		<div id="app">
-			Your browser does not support JavaScript. Please update to a modern browser to use Apiary.
-		</div>
+		<noscript>Your browser does not support JavaScript. Please update to a modern browser to use Apiary.</noscript>
+
+		<div id="app"></div>
 
 		<script src="index.js"></script>
 	</body>


### PR DESCRIPTION
Putting the text about no Javascript support in a noscript tag, will ensure that the text is only shown, if a script tag is not supported, or Javascript is currently disabled.

This also seems to be a common practice [in react](https://github.com/facebook/create-react-app/blob/5d24a5e88f67ad303e2169795f080009241f9f86/packages/cra-template/template/public/index.html#L30-L31).

Fixes #81 