### PR TITLE
Import formatNumber function

### DIFF
--- a/website/src/pages/apps.js
+++ b/website/src/pages/apps.js
@@ -20,7 +20,7 @@ import { WindowedPagination } from '../components/WindowedPagination'
 import { SortHeader } from '../components/SortHeader'
 import { NavTabs } from '../components/NavTabs/NavTabs'
 import openSafe from '../utils/open-safe'
-import formatNumber from '../utils/numbers'
+import { formatNumber } from '../utils/numbers'
 import useSort from '../hooks/sort'
 
 const APPS_QUERY = `

--- a/website/src/pages/orgs.js
+++ b/website/src/pages/orgs.js
@@ -24,7 +24,7 @@ import {
 import { NavTabs } from '../components/NavTabs/NavTabs'
 import useSort from '../hooks/sort'
 import openSafe from '../utils/open-safe'
-import formatNumber from '../utils/numbers'
+import { formatNumber } from '../utils/numbers'
 
 const ORGANISATIONS_QUERY = `
   query(


### PR DESCRIPTION
Currently the orgs and apps pages are trying to use the default
function provided by the numbers.js util, but the util file doesn't
expose any default functions. Assuming the numbers.js file will
expose other number related utils in the future, importing the
specific function does resolve the _resolving_ issue.