### PR TITLE
Add Open Enterprise template to filters

### DIFF
--- a/website/src/pages/orgs.js
+++ b/website/src/pages/orgs.js
@@ -95,7 +95,7 @@ const KITS = [
   {
     label: 'Open Enterprise',
     value: ['0xc54c5dB63aB0E79FBb9555373B969093dEb17859']
-  },  
+  },
   {
     label: 'Reputation',
     value: ['0x3a06A6544e48708142508D9042f94DDdA769d04F']

--- a/website/src/pages/orgs.js
+++ b/website/src/pages/orgs.js
@@ -93,6 +93,10 @@ const KITS = [
     value: ['0x67430642C0c3B5E6538049B9E9eE719f2a4BeE7c']
   },
   {
+    label: 'Open Enterprise',
+    value: ['0xc54c5dB63aB0E79FBb9555373B969093dEb17859']
+  },  
+  {
     label: 'Reputation',
     value: ['0x3a06A6544e48708142508D9042f94DDdA769d04F']
   }


### PR DESCRIPTION
Open Enterprise DAOs are being displayed in Apiary, as it's watching the contract, but there is no way to filter them.

I didn't test this locally, but I assume this change will enable Open Enterprise to be in the filter.