### PR TITLE
Properly format AUM

### DIFF
--- a/website/src/pages/apps.js
+++ b/website/src/pages/apps.js
@@ -150,22 +150,32 @@ export default () => {
                 sortOrder={sort[0] === 'name' && sort[1]}
               />,
               <div key='sort-description'>Description</div>,
-              <SortHeader
-                key='sort-installations'
-                label='Installations'
-                onClick={() => sortBy('installations')}
-                sortOrder={sort[0] === 'installations' && sort[1]}
-              />,
-              <SortHeader
-                key='sort-score'
-                label='Score'
-                onClick={() => sortBy('score')}
-                sortOrder={sort[0] === 'score' && sort[1]}
-                help={{
-                  hint: 'What is App Score?',
-                  body: 'App Score is a relative weighted ranking of Applications derived from organization scores expressed as a percentage.'
-                }}
-              />
+              {
+                label: (
+                  <SortHeader
+                    key='sort-installations'
+                    label='Installations'
+                    onClick={() => sortBy('installations')}
+                    sortOrder={sort[0] === 'installations' && sort[1]}
+                  />
+                ),
+                align: 'end'
+              },
+              {
+                label: (
+                  <SortHeader
+                    key='sort-score'
+                    label='Score'
+                    onClick={() => sortBy('score')}
+                    sortOrder={sort[0] === 'score' && sort[1]}
+                    help={{
+                      hint: 'What is App Score?',
+                      body: 'App Score is a relative weighted ranking of Applications derived from organization scores expressed as a percentage.'
+                    }}
+                  />
+                ),
+                align: 'end'
+              }
             ]}
             entries={data.apps.nodes}
             renderEntry={renderAppEntry}

--- a/website/src/pages/orgs.js
+++ b/website/src/pages/orgs.js
@@ -259,7 +259,7 @@ export default () => {
                 popoverTitle={ens}
               />,
               <div key='org-aum'>
-                ◈ {formatNumber(aum.toFixed(2), ONE_BILLION)}
+                ◈ {formatNumber(aum, ONE_BILLION, true)}
               </div>,
               <div key='org-activity'>
                 {activity}
@@ -291,10 +291,14 @@ export default () => {
         )}
         {loading && <SyncIndicator label='Loading…' />}
       </div>}
-      secondary={<Box>
-        <Text.Block size='xlarge'>{firstFetch ? '-' : formatNumber(data.organisations.totalCount)}</Text.Block>
-        <Text>organisations</Text>
-      </Box>}
+      secondary={
+        <>
+          <Box>
+            <Text.Block size='xlarge'>{firstFetch ? '-' : formatNumber(data.organisations.totalCount)}</Text.Block>
+            <Text>organisations</Text>
+          </Box>
+        </>
+      }
     />
   </div>
 }

--- a/website/src/utils/numbers.js
+++ b/website/src/utils/numbers.js
@@ -8,16 +8,24 @@ const SI_SYMBOLS = [
   'E'
 ]
 
-export function formatNumber (num, cutoff = 10000) {
+export function formatNumber (num, cutoff = 10000, fixedDecimals = false) {
+  const options = [
+    undefined,
+    {
+      minimumFractionDigits: fixedDecimals ? 2 : 0,
+      maximumFractionDigits: 2
+    }
+  ]
+
   if (num < cutoff) {
-    return num.toLocaleString()
+    return num.toLocaleString(...options)
   }
 
   const abs = Math.abs(num)
   const tier = Math.log10(abs) / 3 | 0
 
   if (tier === 0) {
-    return num.toLocaleString()
+    return num.toLocaleString(...options)
   }
 
   const suffix = SI_SYMBOLS[tier]
@@ -25,5 +33,5 @@ export function formatNumber (num, cutoff = 10000) {
 
   const scaled = abs / scale
 
-  return (Math.sign(num) * scaled.toFixed(2)).toLocaleString() + suffix
+  return (Math.sign(num) * scaled).toLocaleString(...options) + suffix
 }


### PR DESCRIPTION
In #137 the comma delimiting is removed by error. Fixing to two decimals preserving the format.

![Screenshot from 2020-01-30 00-49-10](https://user-images.githubusercontent.com/931684/73407764-6ca17800-42fa-11ea-9325-bc4a5a56ca64.png)
