### PR TITLE
Handle malformed organization names

### DIFF
--- a/worker/src/org/name.js
+++ b/worker/src/org/name.js
@@ -6,7 +6,16 @@ export function * persistName (
   tx
 ) {
   const ensName = `${tx.parameters.name}.aragonid.eth`
-  const address = yield call([ctx.web3.eth.ens, 'getAddress', ensName])
+  let address
+  try {
+    address = yield call([ctx.web3.eth.ens, 'getAddress', ensName])
+  } catch (_) {
+    ctx.log.warn({
+      ens: ensName,
+      transactionHash: tx.hash
+    }, `Malformed name found, aborting decoding.`)
+    return
+  }
 
   ctx.log.info({
     organisation: address,


### PR DESCRIPTION
An organization name was malformed (fundraising0.8[...].aragonid.eth) and that stopped indexing from working. This PR just skips such malformed names.

Unfortunately a side effect of this is that we can't detect kits for these organizations.