### PR TITLE
Fix timestamps

### DIFF
--- a/worker/src/app/install.js
+++ b/worker/src/app/install.js
@@ -37,7 +37,7 @@ export function * persistInstall (
         }
       },
       $min: {
-        created_at: log.timestamp
+        created_at: log.timestamp.getTime() / 1000
       }
     }
   )

--- a/worker/src/org/name.js
+++ b/worker/src/org/name.js
@@ -32,7 +32,7 @@ export function * persistName (
         kit: tx.to
       },
       $min: {
-        created_at: tx.timestamp
+        created_at: tx.timestamp.getTime() / 1000
       }
     }
   )


### PR DESCRIPTION
`node-pg` returns timestamps as `Date` objects, where we previously passed around a UNIX timestamp.

This caused newer documents to use one format for timestamp properties in the database and older documents another.