### PR TITLE
Add app score calculation CLI script

### DIFF
--- a/scripts/calcscore
+++ b/scripts/calcscore
@@ -274,6 +274,9 @@ function saveScores ({
     }, {
       id: 'payout',
       title: 'PAYOUT'
+    }, {
+      id: 'eligible',
+      title: 'ELIGIBLE'
     }]
   })
 

--- a/scripts/calcscore
+++ b/scripts/calcscore
@@ -1,0 +1,279 @@
+#!/usr/bin/env node
+const fs = require('fs')
+const got = require('got')
+const _ = require('lodash')
+const { createObjectCsvWriter } = require('csv-writer')
+
+const QUERY = `query(
+  $after: Cursor
+) {
+  organisations(
+    take: 100
+    after: $after
+  ) {
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+    nodes {
+      address
+      activity
+      aum
+      ant
+      proxies {
+        appId
+      }
+    }
+  }
+}`
+
+async function fetchPage (
+  after = null
+) {
+  const {
+    body: { data }
+  } = await got.post('https://daolist.1hive.org', {
+    json: {
+      query: QUERY,
+      variables: {
+        after
+      }
+    },
+    responseType: 'json'
+  })
+
+  return data
+}
+
+async function fetchData (quadratic) {
+  let organisations = []
+  let apps = []
+  const totals = {
+    activity: 1,
+    aum: 1,
+    ant: 1
+  }
+
+  // Fetch all the data
+  let lastCursor
+  let hasNextPage = true
+  while (hasNextPage) {
+    // Fetch the current page
+    const data = await fetchPage(lastCursor)
+    lastCursor = data.organisations.pageInfo.endCursor
+    hasNextPage = data.organisations.pageInfo.hasNextPage
+
+    // Transform organisations in current page
+    let transformed = _.chain(data.organisations.nodes)
+      .map(_.partialRight(_.pick, [
+        'address',
+        'activity',
+        'aum',
+        'ant',
+        'proxies'
+      ]))
+      .map((org) => ({
+        ...org,
+        proxies: org.proxies.length
+      }))
+
+    if (quadratic) {
+      transformed = transformed.map(
+        (org) => ({
+          ...org,
+          activitySqrt: Math.sqrt(org.activity),
+          aumSqrt: Math.sqrt(org.aum),
+          antSqrt: Math.sqrt(org.ant)
+        })
+      )
+    }
+
+    // Extract the data
+    organisations = organisations.concat(
+      transformed.value()
+    )
+    apps = apps.concat(
+      _.chain(data.organisations.nodes)
+        .flatMap((org) => org.proxies.map(
+          (proxy) => ({ organisation: org.address, id: proxy.appId })
+        ))
+        .value()
+    )
+  }
+
+  // Calculate KPI totals
+  if (quadratic) {
+    totals.activity = _.sumBy(organisations, 'activitySqrt')
+    totals.aum = _.sumBy(organisations, 'aumSqrt')
+    totals.ant = _.sumBy(organisations, 'antSqrt')
+  } else {
+    totals.activity = _.sumBy(organisations, 'activity')
+    totals.aum = _.sumBy(organisations, 'aum')
+    totals.ant = _.sumBy(organisations, 'ant')
+  }
+
+  return {
+    organisations: _.keyBy(organisations, 'address'),
+    apps,
+    totals
+  }
+}
+
+function scoring (weights, quadratic) {
+  const [
+    activityWeight,
+    aumWeight,
+    antWeight
+  ] = weights
+  return function (data) {
+    const organisationScores = _.chain(data.organisations)
+      .mapValues((org) => {
+        // Calculate normalized KPIs
+        const normalizedActivity = (quadratic
+          ? org.activitySqrt
+          : org.activity) / data.totals.activity
+        const normalizedAum = (quadratic
+          ? org.aumSqrt
+          : org.aum) / data.totals.aum
+        const normalizedAnt = (quadratic
+          ? org.antSqrt
+          : org.ant) / data.totals.ant
+
+        // Calculate score
+        const score = normalizedActivity * activityWeight + normalizedAum * aumWeight + normalizedAnt * antWeight
+        return {
+          ...org,
+          score
+        }
+      })
+      .value()
+    const appScores = _.chain(data.apps)
+      .groupBy('id')
+      .mapValues((apps) => _.chain(apps)
+        .map((app) => {
+          const organisation = data.organisations[app.organisation]
+
+          const score = organisationScores[app.organisation].score / organisation.proxies
+          return score
+        })
+        .sum()
+        .value()
+      )
+      .flatMap((score, id) => ({ id, score }))
+      .value()
+
+    return {
+      organisationScores: _.chain(organisationScores)
+        .flatMap()
+        .sortBy('score')
+        .reverse()
+        .value(),
+      appScores: _.chain(appScores)
+        .sortBy('score')
+        .reverse()
+        .value()
+    }
+  }
+}
+
+function saveScores ({
+  organisationScores,
+  appScores
+}) {
+  const orgScoreFile = createObjectCsvWriter({
+    path: 'organisation_scores.csv',
+    header: [{
+      id: 'address',
+      title: 'ADDRESS'
+    }, {
+      id: 'activity',
+      title: 'ACTIVITY'
+    }, {
+      id: 'aum',
+      title: 'AUM'
+    }, {
+      id: 'ant',
+      title: 'ANT'
+    }, {
+      id: 'score',
+      title: 'SCORE'
+    }]
+  })
+  const appScoreFile = createObjectCsvWriter({
+    path: 'app_scores.csv',
+    header: [{
+      id: 'id',
+      title: 'APP_ID'
+    }, {
+      id: 'score',
+      title: 'SCORE'
+    }]
+  })
+
+  return Promise.all([
+    orgScoreFile.writeRecords(organisationScores),
+    appScoreFile.writeRecords(appScores)
+  ])
+}
+
+// Parse command line parameters
+const parameters = process.argv.slice(2)
+if (parameters.length < 3) {
+  console.error(`Usage: ./calcscore <activity weight> <aum weight> <ant weight> [--quad]`)
+  process.exit(1)
+}
+
+// Parse --quad flag
+const quadratic = _.indexOf(parameters, '--quad') > 0
+if (quadratic) {
+  parameters.splice(
+    _.indexOf(parameters, '--quad'),
+    1
+  )
+}
+
+// Validate that weights add up to 1
+const weights = _.map(parameters.slice(0, 3), Number)
+const sumOfWeights = _.sum(weights)
+if (sumOfWeights !== 1) {
+  console.error(`The sum of the weights should be 1, is ${sumOfWeights}`)
+  process.exit(1)
+}
+
+// Run script
+console.log(`Calculating app scores (${quadratic ? 'quadratic' : 'linear'}, weights = [${weights.join(', ')}])`)
+console.log('Fetching data...')
+fetchData(quadratic)
+  .then((data) => {
+    console.log('Data fetched.')
+    if (quadratic) {
+      console.log('Note these are the sum of square roots of each KPI.')
+    }
+
+    console.log(`- ${_.size(data.organisations)} organisations`)
+    console.log(`- ${_.size(data.apps)} app instances`)
+    console.log(`- ${data.totals.activity} total activity`)
+    console.log(`- ${data.totals.aum} total AUM`)
+    console.log(`- ${data.totals.ant} total ANT`)
+
+    return data
+  })
+  .then(
+    scoring(weights, quadratic)
+  )
+  .then((scores) => {
+    const orgScoreSum = _.sumBy(scores.organisationScores, 'score')
+    const appScoreSum = _.sumBy(scores.appScores, 'score')
+    console.log('Calculated scores.')
+    console.log(`Sanity check; organisation score sum = ${orgScoreSum}, app score sum = ${appScoreSum}`)
+
+    return scores
+  })
+  .then(saveScores)
+  .then(() => {
+    console.log('Saved scores to disk.')
+  })
+  .catch((err) => {
+    console.error('An error occurred')
+    console.error(err)
+  })

--- a/scripts/calcscore
+++ b/scripts/calcscore
@@ -247,23 +247,22 @@ function saveScores ({
 }
 
 // Parse command line parameters
-const parameters = process.argv.slice(2)
+const {
+  _: parameters,
+  quadratic
+} = require('minimist')(process.argv.slice(2), {
+  alias: {
+    quadratic: 'quad'
+  }
+})
+
 if (parameters.length < 3) {
   console.error(`Usage: ./calcscore <activity weight> <aum weight> <ant weight> [--quad]`)
   process.exit(1)
 }
 
-// Parse --quad flag
-const quadratic = _.indexOf(parameters, '--quad') > 0
-if (quadratic) {
-  parameters.splice(
-    _.indexOf(parameters, '--quad'),
-    1
-  )
-}
-
 // Validate that weights add up to 1
-const weights = _.map(parameters.slice(0, 3), Number)
+const weights = _.map(parameters, Number)
 const sumOfWeights = _.sum(weights)
 if (sumOfWeights !== 1) {
   console.error(`The sum of the weights should be 1, is ${sumOfWeights}`)

--- a/scripts/calcscore
+++ b/scripts/calcscore
@@ -206,6 +206,34 @@ function scoring (weights, quadratic) {
   }
 }
 
+function payouts (
+  scores,
+  eligibleApps = [],
+  potSize = 100000
+) {
+  const eligibleScoreTotal = _.chain(scores.appScores)
+    .filter(({ id }) => eligibleApps.includes(id))
+    .sumBy('score')
+    .value()
+
+  scores.appScores = scores.appScores.map((appScore) => {
+    const eligible = eligibleApps.includes(appScore.id)
+
+    let payout = 0
+    if (eligible) {
+      payout = potSize * (appScore.score / eligibleScoreTotal)
+    }
+
+    return {
+      ...appScore,
+      payout,
+      eligible
+    }
+  })
+
+  return scores
+}
+
 function saveScores ({
   organisationScores,
   appScores
@@ -243,6 +271,9 @@ function saveScores ({
     }, {
       id: 'score',
       title: 'SCORE'
+    }, {
+      id: 'payout',
+      title: 'PAYOUT'
     }]
   })
 
@@ -256,6 +287,7 @@ function saveScores ({
 const {
   _: parameters,
   quadratic,
+  apps: appsWhitelistPath,
   blacklist: orgBlacklistPath
 } = require('minimist')(process.argv.slice(2), {
   alias: {
@@ -273,8 +305,14 @@ if (parameters.length < 3) {
   console.error('Flags:')
   console.error('--quad, --quadratic')
   console.error('\tUse quadratic scoring')
+  console.error('--apps')
+  console.error('\tPath to a file of app IDs eligible for payouts')
   console.error('--blacklist, --blacklisted-orgs')
   console.error('\tPath to a file of organisation addresses that are blacklisted')
+  console.error()
+  console.error('App ID file')
+  console.error('===')
+  console.error('The file used for `--apps` should be a newline delimited file of app IDs')
   console.error()
   console.error('Organisation blacklist file')
   console.error('===')
@@ -301,9 +339,20 @@ if (orgBlacklistPath) {
     .filter(_.identity)
 }
 
+let eligibleApps = []
+if (appsWhitelistPath) {
+  const whitelist = fs.readFileSync(appsWhitelistPath, {
+    encoding: 'utf8'
+  })
+  eligibleApps = whitelist
+    .split('\n')
+    .filter(_.identity)
+}
+
 // Run script
 console.log(`Calculating app scores (${quadratic ? 'quadratic' : 'linear'}, weights = [${weights.join(', ')}])`)
 console.log(`Blacklisted orgs: ${orgBlacklist.length}`)
+console.log(`Eligible apps: ${eligibleApps.length}`)
 console.log('Fetching data...')
 fetchData(quadratic, orgBlacklist)
   .then((data) => {
@@ -329,7 +378,8 @@ fetchData(quadratic, orgBlacklist)
     console.log('Calculated scores.')
     console.log(`Sanity check; organisation score sum = ${orgScoreSum}, app score sum = ${appScoreSum}`)
 
-    return scores
+    console.log('Projecting payouts...')
+    return payouts(scores, eligibleApps)
   })
   .then(saveScores)
   .then(() => {

--- a/scripts/calcscore
+++ b/scripts/calcscore
@@ -67,8 +67,16 @@ async function fetchData (quadratic) {
     lastCursor = data.organisations.pageInfo.endCursor
     hasNextPage = data.organisations.pageInfo.hasNextPage
 
+    // Filter out non-indexed apps
+    const filtered = _.chain(data.organisations.nodes)
+      .map((org) => ({
+        ...org,
+        proxies: org.proxies.filter((proxy) => proxy.app)
+      }))
+      .value()
+
     // Transform organisations in current page
-    let transformed = _.chain(data.organisations.nodes)
+    let transformed = _.chain(filtered)
       .map(_.partialRight(_.pick, [
         'address',
         'ens',
@@ -98,12 +106,12 @@ async function fetchData (quadratic) {
       transformed.value()
     )
     apps = apps.concat(
-      _.chain(data.organisations.nodes)
+      _.chain(filtered)
         .flatMap((org) => org.proxies.map(
           (proxy) => ({
             organisation: org.address,
             id: proxy.appId,
-            name: proxy.app ? proxy.app.name : '-'
+            name: proxy.app.name
           })
         ))
         .value()

--- a/scripts/calcscore
+++ b/scripts/calcscore
@@ -16,12 +16,16 @@ const QUERY = `query(
       endCursor
     }
     nodes {
+      ens
       address
       activity
       aum
       ant
       proxies {
         appId
+        app {
+          name
+        }
       }
     }
   }
@@ -67,6 +71,7 @@ async function fetchData (quadratic) {
     let transformed = _.chain(data.organisations.nodes)
       .map(_.partialRight(_.pick, [
         'address',
+        'ens',
         'activity',
         'aum',
         'ant',
@@ -95,7 +100,11 @@ async function fetchData (quadratic) {
     apps = apps.concat(
       _.chain(data.organisations.nodes)
         .flatMap((org) => org.proxies.map(
-          (proxy) => ({ organisation: org.address, id: proxy.appId })
+          (proxy) => ({
+            organisation: org.address,
+            id: proxy.appId,
+            name: proxy.app ? proxy.app.name : '-'
+          })
         ))
         .value()
     )
@@ -149,17 +158,24 @@ function scoring (weights, quadratic) {
       .value()
     const appScores = _.chain(data.apps)
       .groupBy('id')
-      .mapValues((apps) => _.chain(apps)
-        .map((app) => {
-          const organisation = data.organisations[app.organisation]
+      .mapValues((instances) => {
+        const score = _.chain(instances)
+          .map((instance) => {
+            const organisation = data.organisations[instance.organisation]
 
-          const score = organisationScores[app.organisation].score / organisation.proxies
-          return score
-        })
-        .sum()
-        .value()
-      )
-      .flatMap((score, id) => ({ id, score }))
+            const score = organisationScores[instance.organisation].score / organisation.proxies
+            return score
+          })
+          .sum()
+          .value()
+
+        return {
+          name: instances[0].name,
+          id: instances[0].id,
+          score
+        }
+      })
+      .flatMap()
       .value()
 
     return {
@@ -186,6 +202,9 @@ function saveScores ({
       id: 'address',
       title: 'ADDRESS'
     }, {
+      id: 'ens',
+      title: 'ENS_NAME'
+    }, {
       id: 'activity',
       title: 'ACTIVITY'
     }, {
@@ -204,6 +223,9 @@ function saveScores ({
     header: [{
       id: 'id',
       title: 'APP_ID'
+    }, {
+      id: 'name',
+      title: 'APP_NAME'
     }, {
       id: 'score',
       title: 'SCORE'

--- a/scripts/calcscore
+++ b/scripts/calcscore
@@ -291,14 +291,16 @@ const {
   _: parameters,
   quadratic,
   apps: appsWhitelistPath,
-  blacklist: orgBlacklistPath
+  blacklist: orgBlacklistPath,
+  pot
 } = require('minimist')(process.argv.slice(2), {
   alias: {
     quadratic: 'quad',
     blacklist: 'blacklisted-orgs'
   },
   default: {
-    quadratic: false
+    quadratic: false,
+    pot: 100000
   }
 })
 
@@ -312,6 +314,8 @@ if (parameters.length < 3) {
   console.error('\tPath to a file of app IDs eligible for payouts')
   console.error('--blacklist, --blacklisted-orgs')
   console.error('\tPath to a file of organisation addresses that are blacklisted')
+  console.error('--pot')
+  console.error('\tThe size of the payout pot. Defaults to 100k.')
   console.error()
   console.error('App ID file')
   console.error('===')
@@ -356,6 +360,7 @@ if (appsWhitelistPath) {
 console.log(`Calculating app scores (${quadratic ? 'quadratic' : 'linear'}, weights = [${weights.join(', ')}])`)
 console.log(`Blacklisted orgs: ${orgBlacklist.length}`)
 console.log(`Eligible apps: ${eligibleApps.length}`)
+console.log(`Pot size: ${pot}`)
 console.log('Fetching data...')
 fetchData(quadratic, orgBlacklist)
   .then((data) => {
@@ -382,7 +387,7 @@ fetchData(quadratic, orgBlacklist)
     console.log(`Sanity check; organisation score sum = ${orgScoreSum}, app score sum = ${appScoreSum}`)
 
     console.log('Projecting payouts...')
-    return payouts(scores, eligibleApps)
+    return payouts(scores, eligibleApps, pot)
   })
   .then(saveScores)
   .then(() => {

--- a/scripts/calcscore
+++ b/scripts/calcscore
@@ -49,7 +49,10 @@ async function fetchPage (
   return data
 }
 
-async function fetchData (quadratic) {
+async function fetchData (
+  quadratic,
+  orgBlacklist = []
+) {
   let organisations = []
   let apps = []
   const totals = {
@@ -69,6 +72,9 @@ async function fetchData (quadratic) {
 
     // Filter out non-indexed apps
     const filtered = _.chain(data.organisations.nodes)
+      .filter(
+        ({ address }) => !orgBlacklist.includes(address)
+      )
       .map((org) => ({
         ...org,
         proxies: org.proxies.filter((proxy) => proxy.app)
@@ -249,15 +255,30 @@ function saveScores ({
 // Parse command line parameters
 const {
   _: parameters,
-  quadratic
+  quadratic,
+  blacklist: orgBlacklistPath
 } = require('minimist')(process.argv.slice(2), {
   alias: {
-    quadratic: 'quad'
+    quadratic: 'quad',
+    blacklist: 'blacklisted-orgs'
+  },
+  default: {
+    quadratic: false
   }
 })
 
 if (parameters.length < 3) {
-  console.error(`Usage: ./calcscore <activity weight> <aum weight> <ant weight> [--quad]`)
+  console.error('Usage: ./calcscore <activity weight> <aum weight> <ant weight> [flags]')
+  console.error()
+  console.error('Flags:')
+  console.error('--quad, --quadratic')
+  console.error('\tUse quadratic scoring')
+  console.error('--blacklist, --blacklisted-orgs')
+  console.error('\tPath to a file of organisation addresses that are blacklisted')
+  console.error()
+  console.error('Organisation blacklist file')
+  console.error('===')
+  console.error('The file used for `--blacklist` should be a newline delimited file of checksummed organisation addresses')
   process.exit(1)
 }
 
@@ -269,10 +290,22 @@ if (sumOfWeights !== 1) {
   process.exit(1)
 }
 
+// Process and validate files
+let orgBlacklist = []
+if (orgBlacklistPath) {
+  const blacklist = fs.readFileSync(orgBlacklistPath, {
+    encoding: 'utf8'
+  })
+  orgBlacklist = blacklist
+    .split('\n')
+    .filter(_.identity)
+}
+
 // Run script
 console.log(`Calculating app scores (${quadratic ? 'quadratic' : 'linear'}, weights = [${weights.join(', ')}])`)
+console.log(`Blacklisted orgs: ${orgBlacklist.length}`)
 console.log('Fetching data...')
-fetchData(quadratic)
+fetchData(quadratic, orgBlacklist)
   .then((data) => {
     console.log('Data fetched.')
     if (quadratic) {

--- a/scripts/calcscore
+++ b/scripts/calcscore
@@ -324,6 +324,10 @@ if (parameters.length < 3) {
   console.error('Organisation blacklist file')
   console.error('===')
   console.error('The file used for `--blacklist` should be a newline delimited file of checksummed organisation addresses')
+  console.error()
+  console.error('File comments')
+  console.error('===')
+  console.error('Comments can be added to any file passed to this CLI. Comments start with `//` and anything after it will be ignored')
   process.exit(1)
 }
 
@@ -335,6 +339,12 @@ if (sumOfWeights !== 1) {
   process.exit(1)
 }
 
+function removeComments (item) {
+  return _.trim(
+    item.split('//')[0]
+  )
+}
+
 // Process and validate files
 let orgBlacklist = []
 if (orgBlacklistPath) {
@@ -343,6 +353,7 @@ if (orgBlacklistPath) {
   })
   orgBlacklist = blacklist
     .split('\n')
+    .map(removeComments)
     .filter(_.identity)
 }
 
@@ -353,6 +364,7 @@ if (appsWhitelistPath) {
   })
   eligibleApps = whitelist
     .split('\n')
+    .map(removeComments)
     .filter(_.identity)
 }
 

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -1,0 +1,260 @@
+{
+  "name": "@apiary/scripts",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@sindresorhus/is": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-1.2.0.tgz",
+      "integrity": "sha512-mwhXGkRV5dlvQc4EgPDxDxO6WuMBVymGFd1CA+2Y+z5dG9MNspoQ+AWjl/Ld1MnpCL8AKbosZlDVohqcIwuWsw=="
+    },
+    "@szmarczak/http-timer": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.5.tgz",
+      "integrity": "sha512-PyRA9sm1Yayuj5OIoJ1hGt2YISX45w9WcFbh6ddT0Z/0yaFxOtGLInr4jUfU1EAFVs0Yfyfev4RNwBlUaHdlDQ==",
+      "requires": {
+        "defer-to-connect": "^2.0.0"
+      }
+    },
+    "@types/cacheable-request": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.1.tgz",
+      "integrity": "sha512-ykFq2zmBGOCbpIXtoVbz4SKY5QriWPh3AjyU4G74RYbtt5yOc5OfaY75ftjg7mikMOla1CTGpX3lLbuJh8DTrQ==",
+      "requires": {
+        "@types/http-cache-semantics": "*",
+        "@types/keyv": "*",
+        "@types/node": "*",
+        "@types/responselike": "*"
+      }
+    },
+    "@types/http-cache-semantics": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.0.tgz",
+      "integrity": "sha512-c3Xy026kOF7QOTn00hbIllV1dLR9hG9NkSrLQgCVs8NF6sBU+VGWjD3wLPhmh1TYAc7ugCFsvHYMN4VcBN1U1A=="
+    },
+    "@types/keyv": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.1.tgz",
+      "integrity": "sha512-MPtoySlAZQ37VoLaPcTHCu1RWJ4llDkULYZIzOYxlhxBqYPB0RsRlmMU0R6tahtFe27mIdkHV+551ZWV4PLmVw==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/node": {
+      "version": "13.7.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.1.tgz",
+      "integrity": "sha512-Zq8gcQGmn4txQEJeiXo/KiLpon8TzAl0kmKH4zdWctPj05nWwp1ClMdAVEloqrQKfaC48PNLdgN/aVaLqUrluA=="
+    },
+    "@types/responselike": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
+      "integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "cacheable-lookup": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-2.0.0.tgz",
+      "integrity": "sha512-s2piO6LvA7xnL1AR03wuEdSx3BZT3tIJpZ56/lcJwzO/6DTJZlTs7X3lrvPxk6d1PlDe6PrVe2TjlUIZNFglAQ==",
+      "requires": {
+        "keyv": "^4.0.0"
+      }
+    },
+    "cacheable-request": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.1.tgz",
+      "integrity": "sha512-lt0mJ6YAnsrBErpTMWeu5kl/tg9xMAWjavYTN6VQXM1A/teBITuNcccXsCxF0tDQQJf9DfAaX5O4e0zp0KlfZw==",
+      "requires": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^4.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^4.1.0",
+        "responselike": "^2.0.0"
+      }
+    },
+    "clone-response": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
+      "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+      "requires": {
+        "mimic-response": "^1.0.0"
+      },
+      "dependencies": {
+        "mimic-response": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+          "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
+        }
+      }
+    },
+    "csv-writer": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/csv-writer/-/csv-writer-1.6.0.tgz",
+      "integrity": "sha512-NOx7YDFWEsM/fTRAJjRpPp8t+MKRVvniAg9wQlUKx20MFrPs73WLJhFf5iteqrxNYnsy924K3Iroh3yNHeYd2g=="
+    },
+    "decompress-response": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-5.0.0.tgz",
+      "integrity": "sha512-TLZWWybuxWgoW7Lykv+gq9xvzOsUjQ9tF09Tj6NSTYGMTCHNXzrPnD6Hi+TgZq19PyTAGH4Ll/NIM/eTGglnMw==",
+      "requires": {
+        "mimic-response": "^2.0.0"
+      }
+    },
+    "defer-to-connect": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.0.tgz",
+      "integrity": "sha512-bYL2d05vOSf1JEZNx5vSAtPuBMkX8K9EUutg7zlKvTqKXHt7RhWJFbmd7qakVuf13i+IkGmp6FwSsONOf6VYIg=="
+    },
+    "duplexer3": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
+    },
+    "end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "requires": {
+        "once": "^1.4.0"
+      }
+    },
+    "get-stream": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+      "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+      "requires": {
+        "pump": "^3.0.0"
+      }
+    },
+    "got": {
+      "version": "10.5.5",
+      "resolved": "https://registry.npmjs.org/got/-/got-10.5.5.tgz",
+      "integrity": "sha512-B13HHkCkTA7KxyxTrFoZfrurBX1fZxjMTKpmIfoVzh0Xfs9aZV7xEfI6EKuERQOIPbomh5LE4xDkfK6o2VXksw==",
+      "requires": {
+        "@sindresorhus/is": "^1.0.0",
+        "@szmarczak/http-timer": "^4.0.0",
+        "@types/cacheable-request": "^6.0.1",
+        "cacheable-lookup": "^2.0.0",
+        "cacheable-request": "^7.0.1",
+        "decompress-response": "^5.0.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^5.0.0",
+        "lowercase-keys": "^2.0.0",
+        "mimic-response": "^2.0.0",
+        "p-cancelable": "^2.0.0",
+        "p-event": "^4.0.0",
+        "responselike": "^2.0.0",
+        "to-readable-stream": "^2.0.0",
+        "type-fest": "^0.9.0"
+      }
+    },
+    "http-cache-semantics": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
+      "integrity": "sha512-Z2EICWNJou7Tr9Bd2M2UqDJq3A9F2ePG9w3lIpjoyuSyXFP9QbniJVu3XQYytuw5ebmG7dXSXO9PgAjJG8DDKA=="
+    },
+    "json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
+    },
+    "keyv": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.0.tgz",
+      "integrity": "sha512-U7ioE8AimvRVLfw4LffyOIRhL2xVgmE8T22L6i0BucSnBUyv4w+I7VN/zVZwRKHOI6ZRUcdMdWHQ8KSUvGpEog==",
+      "requires": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "lodash": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+    },
+    "lowercase-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="
+    },
+    "mimic-response": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.0.0.tgz",
+      "integrity": "sha512-8ilDoEapqA4uQ3TwS0jakGONKXVJqpy+RpM+3b7pLdOjghCrEiGp9SRkFbUHAmZW9vdnrENWHjaweIoTIJExSQ=="
+    },
+    "normalize-url": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
+      "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ=="
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "p-cancelable": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.0.0.tgz",
+      "integrity": "sha512-wvPXDmbMmu2ksjkB4Z3nZWTSkJEb9lqVdMaCKpZUGJG9TMiNp9XcbG3fn9fPKjem04fJMJnXoyFPk2FmgiaiNg=="
+    },
+    "p-event": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-event/-/p-event-4.1.0.tgz",
+      "integrity": "sha512-4vAd06GCsgflX4wHN1JqrMzBh/8QZ4j+rzp0cd2scXRwuBEv+QR3wrVA5aLhWDLw4y2WgDKvzWF3CCLmVM1UgA==",
+      "requires": {
+        "p-timeout": "^2.0.1"
+      }
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+    },
+    "p-timeout": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
+      "integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
+      "requires": {
+        "p-finally": "^1.0.0"
+      }
+    },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "responselike": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.0.tgz",
+      "integrity": "sha512-xH48u3FTB9VsZw7R+vvgaKeLKzT6jOogbQhEe/jewwnZgzPcnyWui2Av6JpoYZF/91uueC+lqhWqeURw5/qhCw==",
+      "requires": {
+        "lowercase-keys": "^2.0.0"
+      }
+    },
+    "to-readable-stream": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-2.1.0.tgz",
+      "integrity": "sha512-o3Qa6DGg1CEXshSdvWNX2sN4QHqg03SPq7U6jPXRahlQdl5dK8oXjkU/2/sGrnOZKeGV1zLSO8qPwyKklPPE7w=="
+    },
+    "type-fest": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.9.0.tgz",
+      "integrity": "sha512-j55pzONIdg7rdtJTRZPKIbV0FosUqYdhHK1aAYJIrUvejv1VVyBokrILE8KQDT4emW/1Ev9tx+yZG+AxuSBMmA=="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    }
+  }
+}

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -185,6 +185,11 @@
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.0.0.tgz",
       "integrity": "sha512-8ilDoEapqA4uQ3TwS0jakGONKXVJqpy+RpM+3b7pLdOjghCrEiGp9SRkFbUHAmZW9vdnrENWHjaweIoTIJExSQ=="
     },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+    },
     "normalize-url": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@apiary/scripts",
+  "version": "1.0.0",
+  "description": "",
+  "author": "",
+  "license": "GPLv3",
+  "dependencies": {
+    "csv-writer": "^1.6.0",
+    "got": "^10.5.5",
+    "lodash": "^4.17.15"
+  }
+}

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "csv-writer": "^1.6.0",
     "got": "^10.5.5",
-    "lodash": "^4.17.15"
+    "lodash": "^4.17.15",
+    "minimist": "^1.2.0"
   }
 }


### PR DESCRIPTION
Adds a script that we can use to play around with weights and quadratic scoring.

**Setup**

```
cd scripts
npm i
```

**Usage**

```
Usage: ./calcscore <activity weight> <aum weight> <ant weight> [flags]

Flags:
--quad, --quadratic
	Use quadratic scoring
--apps
	Path to a file of app IDs eligible for payouts
--blacklist, --blacklisted-orgs
	Path to a file of organisation addresses that are blacklisted
--pot
	The size of the payout pot. Defaults to 100k.

App ID file
===
The file used for `--apps` should be a newline delimited file of app IDs

Organisation blacklist file
===
The file used for `--blacklist` should be a newline delimited file of checksummed organisation addresses

File comments
===
Comments can be added to any file passed to this CLI. Comments start with `//` and anything after it will be ignored
```

Where each weight is a value from 0-1. The results are saved to two files on disk in CSV format: `app_scores.csv` and `organisation_scores.csv`.