### PR TITLE
Add total activity and AUM

### DIFF
--- a/api/rollup.config.js
+++ b/api/rollup.config.js
@@ -1,5 +1,5 @@
 import graphql from 'rollup-plugin-graphql'
- 
+
 export default {
   input: 'src/index.js',
   output: {

--- a/api/src/orgs/data.js
+++ b/api/src/orgs/data.js
@@ -43,12 +43,12 @@ export function getOrganisations (
 const augmentWithOrgStats = (query, filter) => async function (obj) {
   return {
     ...obj,
-    ...(await makeOrgStats(query, filter))
+    ...(await fetchOrgStats(query, filter))
   }
 }
 
-async function makeOrgStats (query, filter) {
-  const [{ totalAUM, totalActivity }] = await query.aggregate(
+async function fetchOrgStats (query, filter) {
+  const { totalAUM, totalActivity } = await query.aggregate(
     [
       { $match: filter },
       {
@@ -59,6 +59,6 @@ async function makeOrgStats (query, filter) {
         }
       }
     ]
-  ).toArray()
+  ).next()
   return { totalAUM, totalActivity }
 }

--- a/api/src/orgs/data.js
+++ b/api/src/orgs/data.js
@@ -48,17 +48,14 @@ const augmentWithOrgStats = (query, filter) => async function (obj) {
 }
 
 async function fetchOrgStats (query, filter) {
-  const { totalAUM, totalActivity } = await query.aggregate(
-    [
-      { $match: filter },
-      {
-        $group: {
-          _id: null,
-          totalAUM: { $sum: '$aum' },
-          totalActivity: { $sum: '$activity' }
-        }
-      }
-    ]
-  ).next()
+  const { totalAUM, totalActivity } = await query.aggregate([
+    { $match: filter },
+    {
+      $group: {
+        _id: null,
+        totalAUM: { $sum: '$aum' },
+        totalActivity: { $sum: '$activity' }
+    }
+  }]).next()
   return { totalAUM, totalActivity }
 }

--- a/api/src/orgs/data.js
+++ b/api/src/orgs/data.js
@@ -30,10 +30,35 @@ export function getOrganisations (
     )
   }
 
+  const query = db.collection('orgs')
   return makeConnection(
-    db.collection('orgs'),
+    query,
     args,
     filter,
     camelToSnakeCaseKeys(args.sort)
   )
+    .then(augmentWithOrgStats(query, { ...filter }))
+}
+
+const augmentWithOrgStats = (query, filter) => async function (obj) {
+  return {
+    ...obj,
+    ...(await makeOrgStats(query, filter))
+  }
+}
+
+async function makeOrgStats (query, filter) {
+  const [{ totalAUM, totalActivity }] = await query.aggregate(
+    [
+      { $match: filter },
+      {
+        $group: {
+          _id: null,
+          totalAUM: { $sum: '$aum' },
+          totalActivity: { $sum: '$activity' }
+        }
+      }
+    ]
+  ).toArray()
+  return { totalAUM, totalActivity }
 }

--- a/api/src/orgs/schema.js
+++ b/api/src/orgs/schema.js
@@ -32,6 +32,8 @@ export default `
     nodes: [Organisation]
     pageInfo: PageInfo!
     totalCount: Int!
+    totalAUM: Float!
+    totalActivity: Float!
   }
 
   input OrganisationConnectionFilter {

--- a/api/src/pagination.js
+++ b/api/src/pagination.js
@@ -34,10 +34,6 @@ export async function applyPagination (
     .find(filter)
     .count()
 
-  const { aum: totalAUM, activity: totalActivity } = (await query.find(filter).toArray())
-    .map(({ aum, activity }) => ({ aum, activity }))
-    .reduce((accum, { aum, activity }) => ({ aum: aum + accum.aum, activity: activity + accum.activity }))
-
   let documents = await query
     .find(Object.assign(
       filter,
@@ -75,9 +71,7 @@ export async function applyPagination (
       startCursor,
       endCursor
     },
-    totalCount,
-    totalAUM,
-    totalActivity
+    totalCount
   }
 }
 

--- a/api/src/pagination.js
+++ b/api/src/pagination.js
@@ -34,6 +34,10 @@ export async function applyPagination (
     .find(filter)
     .count()
 
+  const { aum: totalAUM, activity: totalActivity } = (await query.find(filter).toArray())
+    .map(({ aum, activity }) => ({ aum, activity }))
+    .reduce((accum, { aum, activity }) => ({ aum: aum + accum.aum, activity: activity + accum.activity }))
+
   let documents = await query
     .find(Object.assign(
       filter,
@@ -71,7 +75,9 @@ export async function applyPagination (
       startCursor,
       endCursor
     },
-    totalCount
+    totalCount,
+    totalAUM,
+    totalActivity
   }
 }
 

--- a/website/src/pages/orgs.js
+++ b/website/src/pages/orgs.js
@@ -56,6 +56,8 @@ const ORGANISATIONS_QUERY = `
         hasNextPage
       }
       totalCount
+      totalAUM
+      totalActivity
     }
   }
 `
@@ -299,6 +301,14 @@ export default () => {
           <Box>
             <Text.Block size='xlarge'>{firstFetch ? '-' : formatNumber(data.organisations.totalCount)}</Text.Block>
             <Text>organisations</Text>
+          </Box>
+          <Box>
+            <Text.Block size='xlarge'>{firstFetch ? '-' : formatNumber(data.organisations.totalAUM)}</Text.Block>
+            <Text>aggregated AUM</Text>
+          </Box>
+          <Box>
+            <Text.Block size='xlarge'>{firstFetch ? '-' : formatNumber(data.organisations.totalActivity)}</Text.Block>
+            <Text>activities in total</Text>
           </Box>
         </>
       }


### PR DESCRIPTION
![Screenshot from 2020-02-14 23-43-37](https://user-images.githubusercontent.com/931684/74574418-ed5fa580-4f83-11ea-87f6-a00b68c67bd9.png)

AUM and Total activity of the Orgs displayed in the list is shown in the lateral.

I'm worried because it may be misleading. When filtering by timeframe, a user may expect to see how much activity there was in that time, not the last 90 days activity of the orgs created during that timeframe.

I think we may have to rethink the filters at this point, and see how we provide the best UX.