### PR TITLE
Do not display super long names in the org list

### DIFF
--- a/website/src/pages/orgs.js
+++ b/website/src/pages/orgs.js
@@ -258,8 +258,8 @@ export default () => {
               <IdentityBadge
                 key='org-addr'
                 entity={address}
-                customLabel={ens}
-                popoverTitle={ens}
+                customLabel={ens.length <= 42 && ens}
+                popoverTitle={ens.length <= 42 && ens}
               />,
               <div key='org-aum'>
                 ◈ {formatNumber(aum, 2, ONE_BILLION)}

--- a/website/src/pages/orgs.js
+++ b/website/src/pages/orgs.js
@@ -249,7 +249,7 @@ export default () => {
             entries={data.organisations.nodes}
             renderEntry={({
               address,
-              ens = '',
+              ens,
               createdAt,
               aum,
               activity,
@@ -258,8 +258,8 @@ export default () => {
               <IdentityBadge
                 key='org-addr'
                 entity={address}
-                customLabel={ens.length <= 42 && ens}
-                popoverTitle={ens.length <= 42 && ens}
+                customLabel={(ens || '').length <= 42 && ens}
+                popoverTitle={(ens || '').length <= 42 && ens}
               />,
               <div key='org-aum'>
                 ◈ {formatNumber(aum, 2, ONE_BILLION)}

--- a/website/src/pages/orgs.js
+++ b/website/src/pages/orgs.js
@@ -249,7 +249,7 @@ export default () => {
             entries={data.organisations.nodes}
             renderEntry={({
               address,
-              ens,
+              ens = '',
               createdAt,
               aum,
               activity,


### PR DESCRIPTION
Fixes #170 

The list will only show the address of organisations with an ENS name over 42 characters.