### PR TITLE
Analytics: avoid transpiling key analytics script sections

### DIFF
--- a/website/src/index.html
+++ b/website/src/index.html
@@ -32,22 +32,22 @@
 
     <script src="index.js"></script>
     <script type="text/javascript">
-      var Countly = Countly || {};
-      Countly.q = Countly.q || [];
-      Countly.app_key = "0bfb9753483b0094c8407076d77b0719b5a9c2e5";
-      Countly.url = "https://analytics.aragon.org/";
-      Countly.inactivity_time = 10;
-      Countly.q.push(["track_sessions"]);
-      Countly.q.push(["track_pageview"]);
-      Countly.q.push(["track_clicks"]);
-      Countly.q.push(["track_errors"]);
+      window.Countly = window.Countly || {};
+      window.Countly.q = window.Countly.q || [];
+      window.Countly.app_key = "0bfb9753483b0094c8407076d77b0719b5a9c2e5";
+      window.Countly.url = "https://analytics.aragon.org/";
+      window.Countly.inactivity_time = 10;
+      window.Countly.q.push(["track_sessions"]);
+      window.Countly.q.push(["track_pageview"]);
+      window.Countly.q.push(["track_clicks"]);
+      window.Countly.q.push(["track_errors"]);
       (function() {
         var cly = document.createElement("script");
         cly.type = "text/javascript";
         cly.async = true;
         cly.src = "https://analytics.aragon.org/sdk/web/countly.min.js";
         cly.onload = function() {
-          Countly.init();
+          window.Countly.init();
         };
         var s = document.getElementsByTagName("script")[0];
         s.parentNode.insertBefore(cly, s);


### PR DESCRIPTION
Avoids transpiling the global `Countly` variable for the analytics; currently, Parcel is going through the script tag and optimizing variables name, and this is not what we want, as we need the global Countly variable on the window object.